### PR TITLE
feat: add recipe from user token

### DIFF
--- a/src/main/java/org/recipes/recipe/controller/RecipeController.java
+++ b/src/main/java/org/recipes/recipe/controller/RecipeController.java
@@ -45,9 +45,10 @@ public class RecipeController {
     }
 
     @PostMapping("/add")
-    public ResponseEntity<UserRecipe> addRecipe(@RequestBody final AddRecipeRequest request) {
+    public ResponseEntity<UserRecipe> addRecipe(@RequestHeader(name="Authorization") final String token,
+                                                @RequestBody final AddRecipeRequest request) {
         LOG.info("[RecipeController] Received request to add recipe {}", request.getName());
-        return ResponseEntity.ok(this.recipeService.addRecipe(request));
+        return ResponseEntity.ok(this.recipeService.addRecipe(token, request));
     }
 
 }

--- a/src/main/java/org/recipes/recipe/dto/request/AddRecipeRequest.java
+++ b/src/main/java/org/recipes/recipe/dto/request/AddRecipeRequest.java
@@ -9,7 +9,6 @@ import java.util.List;
 @Builder
 public class AddRecipeRequest {
 
-    private final Integer userId;
     private final String name;
     private final String description;
     private final String weblink;

--- a/src/main/java/org/recipes/recipe/service/RecipeService.java
+++ b/src/main/java/org/recipes/recipe/service/RecipeService.java
@@ -11,6 +11,7 @@ import org.recipes.recipe.dto.response.UserRecipe;
 import org.recipes.recipe.entity.RecipeEntity;
 import org.recipes.recipe.entity.RecipeIngredientEntity;
 import org.recipes.recipe.repository.RecipeRepository;
+import org.recipes.user.service.UserService;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -21,6 +22,7 @@ import java.util.List;
 public class RecipeService {
 
     private final RecipeRepository recipeRepository;
+    private final UserService userService;
 
     public List<UserRecipe> getByUserId(final Integer userId) {
         List<RecipeEntity> recipeEntities = this.recipeRepository.findAllByUserId(userId);
@@ -47,15 +49,18 @@ public class RecipeService {
         return mapToUserRecipe(recipeEntity);
     }
 
-    public UserRecipe addRecipe(final AddRecipeRequest request) {
+    public UserRecipe addRecipe(final String token, final AddRecipeRequest request) {
+        final Integer userId = userService.getUserIdByToken(token);
+        LOG.info("[RecipeService] Saving recipe {} for user {}", request.getName(), userId);
         LOG.debug("[RecipeService] Saving recipe: {}", request);
-        final RecipeEntity savedRecipe = recipeRepository.save(toRecipe(request));
+        final RecipeEntity savedRecipe = recipeRepository.save(toRecipe(userId, request));
+        LOG.info("[RecipeService] Saved new recipe with ID: {}", savedRecipe.getRecipeId());
         return mapToUserRecipe(savedRecipe);
     }
 
-    private RecipeEntity toRecipe(final AddRecipeRequest request) {
+    private RecipeEntity toRecipe(final Integer userId, final AddRecipeRequest request) {
         return RecipeEntity.builder()
-                .userId(request.getUserId())
+                .userId(userId)
                 .name(request.getName())
                 .description(request.getDescription())
                 .weblink(request.getWeblink())

--- a/src/main/java/org/recipes/user/repository/UserRepository.java
+++ b/src/main/java/org/recipes/user/repository/UserRepository.java
@@ -1,6 +1,7 @@
 package org.recipes.user.repository;
 
 import org.recipes.user.entity.UserEntity;
+import org.recipes.user.repository.dto.UserEntityId;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
@@ -8,5 +9,7 @@ import java.util.Optional;
 public interface UserRepository extends JpaRepository<UserEntity, Integer> {
 
     Optional<UserEntity> findUserByEmail(String email);
+
+    Optional<UserEntityId> findUserIdByEmail(String email);
 
 }

--- a/src/main/java/org/recipes/user/repository/dto/UserEntityId.java
+++ b/src/main/java/org/recipes/user/repository/dto/UserEntityId.java
@@ -1,0 +1,4 @@
+package org.recipes.user.repository.dto;
+
+public record UserEntityId(Integer userId) {
+}

--- a/src/test/java/org/recipes/recipe/controller/RecipeControllerIntTest.java
+++ b/src/test/java/org/recipes/recipe/controller/RecipeControllerIntTest.java
@@ -126,10 +126,12 @@ class RecipeControllerIntTest extends IntegrationTest {
         // given
         userHelper.saveUsers();
         ingredientHelper.saveIngredients();
+        final String token = String.format("Bearer %s", JwtHelper.generateToken(USER_1_EMAIL));
 
-        final AddRecipeRequest request = addRecipeRequest(USER_ID_1).build();
+        final AddRecipeRequest request = addRecipeRequest().build();
         // when
         final Response response = given()
+                .header("Authorization", token)
                 .body(request)
                 .contentType(ContentType.JSON)
                 .post("/recipe/add");

--- a/src/test/java/org/recipes/testutils/builder/AddRecipeRequestTestBuilder.java
+++ b/src/test/java/org/recipes/testutils/builder/AddRecipeRequestTestBuilder.java
@@ -9,9 +9,8 @@ import java.util.List;
 
 public class AddRecipeRequestTestBuilder {
 
-    public static AddRecipeRequestBuilder addRecipeRequest(final Integer userId) {
+    public static AddRecipeRequestBuilder addRecipeRequest() {
         return AddRecipeRequest.builder()
-                .userId(userId)
                 .name("recipe-name")
                 .description("recipe-description")
                 .weblink("www.recipe-book.com")

--- a/src/test/java/org/recipes/user/service/UserServiceTest.java
+++ b/src/test/java/org/recipes/user/service/UserServiceTest.java
@@ -30,14 +30,14 @@ class UserServiceTest {
     private static final String PASSWORDS_DONT_MATCH_MESSAGE = "Passwords do not match";
 
     @Mock UserRepository userRepository;
-    @InjectMocks UserService underTest;
+    @InjectMocks UserService userService;
 
     @Test
     void getUser_throws_exception_for_unknown_id() {
         // given
         when(userRepository.findById(1)).thenReturn(Optional.empty());
         // then
-        assertThatThrownBy(() -> underTest.getUser(1))
+        assertThatThrownBy(() -> userService.getUser(1))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessage("User not found for ID: 1");
     }
@@ -47,7 +47,7 @@ class UserServiceTest {
         // given
         when(userRepository.findById(1)).thenReturn(Optional.empty());
         // then
-        assertThatThrownBy(() -> underTest.deleteUser(1))
+        assertThatThrownBy(() -> userService.deleteUser(1))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessage("User not found for ID: 1");
     }
@@ -60,7 +60,7 @@ class UserServiceTest {
                 .build();
         when(userRepository.findById(1)).thenReturn(Optional.empty());
         // then
-        assertThatThrownBy(() -> underTest.updateUser(request))
+        assertThatThrownBy(() -> userService.updateUser(request))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessage("User not found for ID: 1");
     }
@@ -77,7 +77,7 @@ class UserServiceTest {
                 .build();
 
         // when, then
-        assertThatThrownBy(() -> underTest.addUser(addUserRequest))
+        assertThatThrownBy(() -> userService.addUser(addUserRequest))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessage(String.format("Invalid request to add user: [%s, %s, %s, %s, %s]",
                         INVALID_EMAIL_MESSAGE, INVALID_FIRST_NAME_MESSAGE, INVALID_SECOND_NAME_MESSAGE,
@@ -98,7 +98,7 @@ class UserServiceTest {
         when(userRepository.findUserByEmail("email@domain.com")).thenReturn(Optional.of(new UserEntity()));
 
         // when, then
-        assertThatThrownBy(() -> underTest.addUser(addUserRequest))
+        assertThatThrownBy(() -> userService.addUser(addUserRequest))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessage(String.format("Invalid request to add user: [%s]", EMAIL_ALREADY_IN_USE_MESSAGE));
     }
@@ -109,7 +109,7 @@ class UserServiceTest {
         final String token = String.format("Bearer %s", JwtHelper.generateToken("test-email@email.com"));
         when(userRepository.findUserIdByEmail("test-email@email.com")).thenReturn(Optional.of(new UserEntityId(123)));
         // when, then
-        assertThat(underTest.getUserIdByToken(token)).isEqualTo(123);
+        assertThat(userService.getUserIdByToken(token)).isEqualTo(123);
     }
 
     @Test
@@ -117,7 +117,7 @@ class UserServiceTest {
         // given
         final String token = String.format("Bearer %s", JwtHelper.generateToken("test-email@email.com"));
         // when, then
-        assertThatThrownBy(() -> underTest.getUserIdByToken(token))
+        assertThatThrownBy(() -> userService.getUserIdByToken(token))
                 .isInstanceOf(UsernameNotFoundException.class)
                 .hasMessage("User not found with email: test-email@email.com");
     }


### PR DESCRIPTION
PR to update the add recipe endpoint to find the user from the auth token, rather than taking a userId parameter in the request body. This is so the front end just has to send the token rather than explicitly sending the userId in the request.